### PR TITLE
breaking: rename types and remove prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+This version marks the first stable release of the library. The API has been significantly reworked since the initial release to be more idiomatic. The dependency for handling dates was switched from the `time` crate to the `jiff` crate, and the MSRV has been bumped to 1.70.0 to align with the `jiff` crate.
+
 ### Documentation
 - Fixed a typo in the summary of the `ArxivIdError::InvalidId` variant
 
@@ -22,6 +24,16 @@
 ### Breaking changes
 - MSRV: Bumps the minimum supported Rust version from 1.63.0 to 1.70.0, since jiff 0.1.14 requires 1.70.0
 - Migrate date handling from the time crate to the jiff crate
+- Rename `ArxivArchive` to `Archive`
+- Rename `ArxivId` to `ArticleId`
+- Rename `ArxivIdError` to `ArticleIdError`
+- Rename `ArxivIdResult` to `ArticleIdResult`
+- Rename `ArxivIdScheme` to `ArticleIdScheme`
+- Rename `ArxivCategoryId` to `Category`
+- Rename `ArxivGroup` to `Group`
+- Rename `ArxivStamp` to `Stamp`
+- Rename `ArxivStampError` to `StampError`
+- Rename `ArxivStampResult` to `StampResult`
 - `ArxivIdError`: now marked with `#[non_exhaustive]`
 - `ArxivIdError`: removed `ArxividError::Syntax` variant
 - `ArxivStampError`: now marked with `#[non_exhaustive]`

--- a/README.md
+++ b/README.md
@@ -24,33 +24,33 @@ cargo add arxiv
 
 ## Usage
 
-### Identifiers
+## Identifiers
 ```rust
-use arxiv::{ArticleVersion, ArxivId};
+use arxiv::{ArticleId, ArticleVersion};
 
-let id = ArxivId::try_from("arXiv:9912.12345v2").unwrap();
+let id = ArticleId::try_from("arXiv:9912.12345v2").unwrap();
 assert_eq!(id.month(), 12);
 assert_eq!(id.year(), 2099);
 assert_eq!(id.number(), "12345");
 assert_eq!(id.version(), ArticleVersion::Num(2));
 ```
 
-### Categories
+## Categories
 ```rust
-use arxiv::{ArxivArchive, ArxivCategoryId, ArxivGroup};
+use arxiv::{Archive, CategoryId, Group};
 
-let category = ArxivCategoryId::try_from("astro-ph.HE").unwrap();
-assert_eq!(category.group(), ArxivGroup::Physics);
-assert_eq!(category.archive(), ArxivArchive::AstroPh);
+let category = CategoryId::try_from("astro-ph.HE").unwrap();
+assert_eq!(category.group(), Group::Physics);
+assert_eq!(category.archive(), Archive::AstroPh);
 assert_eq!(category.subject(), "HE");
 ```
 
-### Stamps
+## Stamps
 ```rust
-use arxiv::{ArxivArchive, ArxivCategoryId, ArxivStamp};
+use arxiv::{Archive, CategoryId, Stamp};
 
-let stamp = ArxivStamp::try_from("arXiv:0706.0001v1 [q-bio.CB] 1 Jun 2007").unwrap();
-assert_eq!(stamp.category, ArxivCategoryId::try_new(ArxivArchive::QBio, "CB").unwrap());
+let stamp = Stamp::try_from("arXiv:0706.0001v1 [q-bio.CB] 1 Jun 2007").unwrap();
+assert_eq!(stamp.category, CategoryId::try_new(Archive::QBio, "CB").unwrap());
 assert_eq!(stamp.submitted.year(), 2007);
 ```
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -4,16 +4,16 @@ use std::str::FromStr;
 
 /// An identifier for arXiv categories, which are composed of an archive and category
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ArxivCategoryId<'a> {
-	group: ArxivGroup,
-	archive: ArxivArchive,
+pub struct CategoryId<'a> {
+	group: Group,
+	archive: Archive,
 	subject: &'a str,
 }
 
-impl<'a> ArxivCategoryId<'a> {
+impl<'a> CategoryId<'a> {
 	pub(crate) const TOKEN_DELIM: char = '.';
 
-	pub(super) const fn new(group: ArxivGroup, archive: ArxivArchive, subject: &'a str) -> Self {
+	pub(super) const fn new(group: Group, archive: Archive, subject: &'a str) -> Self {
 		Self {
 			group,
 			archive,
@@ -26,41 +26,41 @@ impl<'a> ArxivCategoryId<'a> {
 	/// Valid archive identifiers are listed under the official website's page for [category taxonomy][arxiv-cat].
 	///
 	/// [arxiv-cat]: <https://arxiv.org/category_taxonomy>
-	pub fn try_new(archive: ArxivArchive, subject: &'a str) -> Option<Self> {
+	pub fn try_new(archive: Archive, subject: &'a str) -> Option<Self> {
 		let is_valid = match archive {
-			ArxivArchive::AstroPh => matches!(subject, "CO" | "EP" | "GA" | "HE" | "IM" | "SR"),
-			ArxivArchive::CondMat => matches!(subject, |"dis-nn"| "mes-hall"
+			Archive::AstroPh => matches!(subject, "CO" | "EP" | "GA" | "HE" | "IM" | "SR"),
+			Archive::CondMat => matches!(subject, |"dis-nn"| "mes-hall"
 				| "mtrl-sci" | "other"
 				| "quant-gas"
 				| "soft" | "stat-mech"
 				| "str-el" | "supr-con"),
-			ArxivArchive::Cs => COMPSCI_TABLE.binary_search(&subject).is_ok(),
-			ArxivArchive::Econ => matches!(subject, "EM" | "GN" | "TH"),
-			ArxivArchive::Eess => matches!(subject, "AS" | "IV" | "SP" | "SY"),
-			ArxivArchive::GrQc => subject.is_empty(),
-			ArxivArchive::HepEx => subject.is_empty(),
-			ArxivArchive::HepLat => subject.is_empty(),
-			ArxivArchive::HepPh => subject.is_empty(),
-			ArxivArchive::HepTh => subject.is_empty(),
-			ArxivArchive::MathPh => subject.is_empty(),
-			ArxivArchive::Math => MATH_TABLE.binary_search(&subject).is_ok(),
-			ArxivArchive::Nlin => matches!(subject, "AO" | "CD" | "CG" | "PS" | "SI"),
-			ArxivArchive::NuclEx => subject.is_empty(),
-			ArxivArchive::NuclTh => subject.is_empty(),
-			ArxivArchive::Physics => PHYSICS_TABLE.binary_search(&subject).is_ok(),
-			ArxivArchive::QBio => matches!(
+			Archive::Cs => COMPSCI_TABLE.binary_search(&subject).is_ok(),
+			Archive::Econ => matches!(subject, "EM" | "GN" | "TH"),
+			Archive::Eess => matches!(subject, "AS" | "IV" | "SP" | "SY"),
+			Archive::GrQc => subject.is_empty(),
+			Archive::HepEx => subject.is_empty(),
+			Archive::HepLat => subject.is_empty(),
+			Archive::HepPh => subject.is_empty(),
+			Archive::HepTh => subject.is_empty(),
+			Archive::MathPh => subject.is_empty(),
+			Archive::Math => MATH_TABLE.binary_search(&subject).is_ok(),
+			Archive::Nlin => matches!(subject, "AO" | "CD" | "CG" | "PS" | "SI"),
+			Archive::NuclEx => subject.is_empty(),
+			Archive::NuclTh => subject.is_empty(),
+			Archive::Physics => PHYSICS_TABLE.binary_search(&subject).is_ok(),
+			Archive::QBio => matches!(
 				subject,
 				"BM" | "CB" | "GN" | "MN" | "NC" | "OT" | "PE" | "QM" | "SC" | "TO"
 			),
-			ArxivArchive::QFin => {
+			Archive::QFin => {
 				matches!(subject, "CP" | "EC" | "GN" | "MF" | "PM" | "PR" | "RM" | "ST" | "SR")
 			}
-			ArxivArchive::QuantPh => subject.is_empty(),
-			ArxivArchive::Stat => matches!(subject, "AP" | "CO" | "ME" | "ML" | "OT" | "TH"),
+			Archive::QuantPh => subject.is_empty(),
+			Archive::Stat => matches!(subject, "AP" | "CO" | "ME" | "ML" | "OT" | "TH"),
 		};
 
 		match is_valid {
-			true => Some(Self::new(ArxivGroup::from(archive), archive, subject)),
+			true => Some(Self::new(Group::from(archive), archive, subject)),
 			false => None,
 		}
 	}
@@ -75,7 +75,7 @@ impl<'a> ArxivCategoryId<'a> {
 	/// The group, which contains one or more archives
 	#[must_use]
 	#[inline]
-	pub const fn group(&self) -> ArxivGroup {
+	pub const fn group(&self) -> Group {
 		self.group
 	}
 
@@ -83,7 +83,7 @@ impl<'a> ArxivCategoryId<'a> {
 	/// that relate to each other by a specific field of study
 	#[must_use]
 	#[inline]
-	pub const fn archive(&self) -> ArxivArchive {
+	pub const fn archive(&self) -> Archive {
 		self.archive
 	}
 
@@ -95,13 +95,13 @@ impl<'a> ArxivCategoryId<'a> {
 	}
 }
 
-impl<'a> Display for ArxivCategoryId<'a> {
+impl<'a> Display for CategoryId<'a> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		write!(f, "{}.{}", self.archive, self.subject)
 	}
 }
 
-impl<'a> TryFrom<&'a str> for ArxivCategoryId<'a> {
+impl<'a> TryFrom<&'a str> for CategoryId<'a> {
 	type Error = ();
 	fn try_from(s: &'a str) -> Result<Self, Self::Error> {
 		let parts: Vec<&str> = s.split(Self::TOKEN_DELIM).collect();
@@ -109,7 +109,7 @@ impl<'a> TryFrom<&'a str> for ArxivCategoryId<'a> {
 			return Err(());
 		}
 
-		let archive = ArxivArchive::from_str(parts[0])?;
+		let archive = Archive::from_str(parts[0])?;
 		let subject = parts[1];
 
 		Self::try_new(archive, subject).ok_or(())
@@ -118,7 +118,7 @@ impl<'a> TryFrom<&'a str> for ArxivCategoryId<'a> {
 
 /// A type of classification for arXiv publications
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArxivGroup {
+pub enum Group {
 	/// Computer Science
 	Cs,
 	/// Economics
@@ -137,29 +137,29 @@ pub enum ArxivGroup {
 	Stat,
 }
 
-impl From<ArxivArchive> for ArxivGroup {
-	fn from(archive: ArxivArchive) -> Self {
+impl From<Archive> for Group {
+	fn from(archive: Archive) -> Self {
 		match archive {
-			ArxivArchive::Cs => Self::Cs,
-			ArxivArchive::Econ => Self::Econ,
-			ArxivArchive::Eess => Self::Eess,
-			ArxivArchive::Math => Self::Math,
-			ArxivArchive::AstroPh
-			| ArxivArchive::CondMat
-			| ArxivArchive::GrQc
-			| ArxivArchive::HepEx
-			| ArxivArchive::HepLat
-			| ArxivArchive::HepPh
-			| ArxivArchive::HepTh
-			| ArxivArchive::MathPh
-			| ArxivArchive::Nlin
-			| ArxivArchive::NuclEx
-			| ArxivArchive::NuclTh
-			| ArxivArchive::Physics
-			| ArxivArchive::QuantPh => Self::Physics,
-			ArxivArchive::QBio => Self::QBio,
-			ArxivArchive::QFin => Self::QFin,
-			ArxivArchive::Stat => Self::Stat,
+			Archive::Cs => Self::Cs,
+			Archive::Econ => Self::Econ,
+			Archive::Eess => Self::Eess,
+			Archive::Math => Self::Math,
+			Archive::AstroPh
+			| Archive::CondMat
+			| Archive::GrQc
+			| Archive::HepEx
+			| Archive::HepLat
+			| Archive::HepPh
+			| Archive::HepTh
+			| Archive::MathPh
+			| Archive::Nlin
+			| Archive::NuclEx
+			| Archive::NuclTh
+			| Archive::Physics
+			| Archive::QuantPh => Self::Physics,
+			Archive::QBio => Self::QBio,
+			Archive::QFin => Self::QFin,
+			Archive::Stat => Self::Stat,
 		}
 	}
 }
@@ -170,7 +170,7 @@ impl From<ArxivArchive> for ArxivGroup {
 ///
 /// [arxiv-cat]: <https://arxiv.org/category_taxonomy>
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArxivArchive {
+pub enum Archive {
 	/// Astro physics
 	AstroPh,
 	/// Condensed matter
@@ -213,34 +213,34 @@ pub enum ArxivArchive {
 	Stat,
 }
 
-impl Display for ArxivArchive {
+impl Display for Archive {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		match self {
-			ArxivArchive::AstroPh => f.write_str("astro-ph"),
-			ArxivArchive::CondMat => f.write_str("cond-mat"),
-			ArxivArchive::Cs => f.write_str("cs"),
-			ArxivArchive::Econ => f.write_str("econ"),
-			ArxivArchive::Eess => f.write_str("eess"),
-			ArxivArchive::GrQc => f.write_str("gr-qc"),
-			ArxivArchive::HepEx => f.write_str("hep-ex"),
-			ArxivArchive::HepLat => f.write_str("hep-lat"),
-			ArxivArchive::HepPh => f.write_str("hep-ph"),
-			ArxivArchive::HepTh => f.write_str("hep-th"),
-			ArxivArchive::MathPh => f.write_str("math-ph"),
-			ArxivArchive::Math => f.write_str("math"),
-			ArxivArchive::Nlin => f.write_str("nlin"),
-			ArxivArchive::NuclEx => f.write_str("nucl-ex"),
-			ArxivArchive::NuclTh => f.write_str("nucl-th"),
-			ArxivArchive::Physics => f.write_str("physics"),
-			ArxivArchive::QBio => f.write_str("q-bio"),
-			ArxivArchive::QFin => f.write_str("q-fin"),
-			ArxivArchive::QuantPh => f.write_str("quant-ph"),
-			ArxivArchive::Stat => f.write_str("stat"),
+			Archive::AstroPh => f.write_str("astro-ph"),
+			Archive::CondMat => f.write_str("cond-mat"),
+			Archive::Cs => f.write_str("cs"),
+			Archive::Econ => f.write_str("econ"),
+			Archive::Eess => f.write_str("eess"),
+			Archive::GrQc => f.write_str("gr-qc"),
+			Archive::HepEx => f.write_str("hep-ex"),
+			Archive::HepLat => f.write_str("hep-lat"),
+			Archive::HepPh => f.write_str("hep-ph"),
+			Archive::HepTh => f.write_str("hep-th"),
+			Archive::MathPh => f.write_str("math-ph"),
+			Archive::Math => f.write_str("math"),
+			Archive::Nlin => f.write_str("nlin"),
+			Archive::NuclEx => f.write_str("nucl-ex"),
+			Archive::NuclTh => f.write_str("nucl-th"),
+			Archive::Physics => f.write_str("physics"),
+			Archive::QBio => f.write_str("q-bio"),
+			Archive::QFin => f.write_str("q-fin"),
+			Archive::QuantPh => f.write_str("quant-ph"),
+			Archive::Stat => f.write_str("stat"),
 		}
 	}
 }
 
-impl FromStr for ArxivArchive {
+impl FromStr for Archive {
 	type Err = ();
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		match s {
@@ -275,25 +275,25 @@ mod tests {
 
 	#[test]
 	fn parse_category_id() {
-		let cat_id = ArxivCategoryId::try_from("cs.LG");
-		assert_eq!(cat_id, Ok(ArxivCategoryId::new(ArxivGroup::Cs, ArxivArchive::Cs, "LG")));
+		let cat_id = CategoryId::try_from("cs.LG");
+		assert_eq!(cat_id, Ok(CategoryId::new(Group::Cs, Archive::Cs, "LG")));
 	}
 
 	#[test]
 	fn display_category() {
-		let cat_id = ArxivCategoryId::try_new(ArxivArchive::AstroPh, "HE");
+		let cat_id = CategoryId::try_new(Archive::AstroPh, "HE");
 		assert_eq!(cat_id.unwrap().to_string(), "astro-ph.HE");
 	}
 
 	#[test]
 	fn group_from_archive() {
-		let cat_id = ArxivGroup::from(ArxivArchive::AstroPh);
-		assert_eq!(cat_id, ArxivGroup::Physics);
+		let cat_id = Group::from(Archive::AstroPh);
+		assert_eq!(cat_id, Group::Physics);
 	}
 
 	#[test]
 	fn parse_archive() {
-		let archive = ArxivArchive::from_str("astro-ph");
-		assert_eq!(archive, Ok(ArxivArchive::AstroPh));
+		let archive = Archive::from_str("astro-ph");
+		assert_eq!(archive, Ok(Archive::AstroPh));
 	}
 }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -1,13 +1,13 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
-/// Convenient type alias for a [`Result`] holding either an [`ArxivId`] or [`ArxivIdError`]
-pub type ArxivIdResult<'a> = Result<ArxivId<'a>, ArxivIdError>;
+/// Convenient type alias for a [`Result`] holding either an [`ArticleId`] or [`ArticleIdError`]
+pub type ArticleIdResult<'a> = Result<ArticleId<'a>, ArticleIdError>;
 
 /// An error that can occur when parsing and validating arXiv identifiers
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArxivIdError {
+pub enum ArticleIdError {
 	/// Expected the identifier to start with the string literal "arXiv"
 	ExpectedBeginningLiteral,
 	/// Expected to find a `numbervV` component
@@ -20,9 +20,9 @@ pub enum ArxivIdError {
 	InvalidId,
 }
 
-impl Error for ArxivIdError {}
+impl Error for ArticleIdError {}
 
-impl Display for ArxivIdError {
+impl Display for ArticleIdError {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Self::ExpectedBeginningLiteral => {
@@ -44,22 +44,22 @@ impl Display for ArxivIdError {
 ///
 /// # Examples
 /// ```
-/// use arxiv::ArxivId;
+/// use arxiv::ArticleId;
 ///
-/// let id = ArxivId::try_from("arXiv:2001.00001");
+/// let id = ArticleId::try_from("arXiv:2001.00001");
 /// assert!(id.is_ok());
 /// ```
 ///
 /// [arxiv-docs]: https://info.arxiv.org/help/arxiv_identifier.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ArxivId<'a> {
+pub struct ArticleId<'a> {
 	year: i16,
 	month: i8,
 	number: &'a str,
 	version: ArticleVersion,
 }
 
-impl<'a> ArxivId<'a> {
+impl<'a> ArticleId<'a> {
 	pub const MIN_YEAR: i16 = 2007i16;
 	pub const MAX_YEAR: i16 = 2099i16;
 	pub const MIN_NUM_DIGITS: usize = 4usize;
@@ -70,7 +70,7 @@ impl<'a> ArxivId<'a> {
 	pub(crate) const TOKEN_DOT: char = '.';
 	pub(crate) const TOKEN_VERSION: char = 'v';
 
-	/// This allows manually creating an [`ArxivId`] from the given components without any
+	/// This allows manually creating an [`ArticleId`] from the given components without any
 	/// validation. Only do this if you have already verified that the components are valid.
 	///
 	/// # Safety
@@ -80,9 +80,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId};
+	/// use arxiv::{ArticleId, ArticleVersion};
 	///
-	/// let id = ArxivId::new(2011, 1, "00001", ArticleVersion::Num(1));
+	/// let id = ArticleId::new(2011, 1, "00001", ArticleVersion::Num(1));
 	/// ```
 	#[inline]
 	pub const fn new(year: i16, month: i8, number: &'a str, version: ArticleVersion) -> Self {
@@ -94,7 +94,7 @@ impl<'a> ArxivId<'a> {
 		}
 	}
 
-	/// This allows manually creating an [`ArxivId`] from the given components without any version
+	/// This allows manually creating an [`ArticleId`] from the given components without any version
 	/// (assuming it is the latest version). Only do this if you have already verified that the
 	/// components are valid:
 	///
@@ -104,16 +104,16 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId};
+	/// use arxiv::{ArticleId, ArticleVersion};
 	///
-	/// let id = ArxivId::new_latest(2011, 1, "00001");
+	/// let id = ArticleId::new_latest(2011, 1, "00001");
 	/// ```
 	#[inline]
 	pub const fn new_latest(year: i16, month: i8, id: &'a str) -> Self {
 		Self::new(year, month, id, ArticleVersion::Latest)
 	}
 
-	/// This allows manually creating an [`ArxivId`] from the given components with a specific version.
+	/// This allows manually creating an [`ArticleId`] from the given components with a specific version.
 	/// Only do this if you have already verified that the components are valid:
 	///
 	///  - The year is between the inclusive range of [2007, 2009].
@@ -122,24 +122,24 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId};
+	/// use arxiv::{ArticleId, ArticleVersion};
 	///
-	/// let id = ArxivId::new_versioned(2011, 1, "00001", 1);
+	/// let id = ArticleId::new_versioned(2011, 1, "00001", 1);
 	/// assert_eq!(id.version(), ArticleVersion::Num(1));
 	/// ```
 	pub const fn new_versioned(year: i16, month: i8, id: &'a str, version: u8) -> Self {
 		Self::new(year, month, id, ArticleVersion::Num(version))
 	}
 
-	/// This allows manually creating an [`ArxivId`] from the given components with a version, and
+	/// This allows manually creating an [`ArticleId`] from the given components with a version, and
 	/// will also validate each component for correctness. If any component is invalid, it will return
-	/// an [`ArxivIdError`].
+	/// an [`ArticleIdError`].
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId, ArxivIdError};
+	/// use arxiv::{ArticleId, ArticleIdError, ArticleVersion};
 	///
-	/// let id = ArxivId::try_new(2011, 1, "00001", ArticleVersion::Num(1));
+	/// let id = ArticleId::try_new(2011, 1, "00001", ArticleVersion::Num(1));
 	/// assert!(id.is_ok());
 	/// ```
 	pub fn try_new(
@@ -147,37 +147,37 @@ impl<'a> ArxivId<'a> {
 		month: i8,
 		number: &'a str,
 		version: ArticleVersion,
-	) -> ArxivIdResult {
+	) -> ArticleIdResult {
 		if !(Self::MIN_YEAR..=Self::MAX_YEAR).contains(&year) {
-			return Err(ArxivIdError::InvalidYear);
+			return Err(ArticleIdError::InvalidYear);
 		}
 
 		if !(Self::MIN_MONTH..=Self::MAX_MONTH).contains(&month) {
-			return Err(ArxivIdError::InvalidMonth);
+			return Err(ArticleIdError::InvalidMonth);
 		}
 
 		let length_check = (Self::MIN_NUM_DIGITS..=Self::MAX_NUM_DIGITS).contains(&number.len());
 		let digit_check = number.chars().all(|c| c.is_ascii_digit());
 		if !length_check || !digit_check {
-			return Err(ArxivIdError::InvalidId);
+			return Err(ArticleIdError::InvalidId);
 		}
 
 		Ok(Self::new(year, month, number, version))
 	}
 
-	/// This allows manually creating an [`ArxivId`] from the given components without a version
+	/// This allows manually creating an [`ArticleId`] from the given components without a version
 	/// (assuming it is the latest version), and will also validate each component for correctness.
-	/// If any component is invalid, it will return an [`ArxivIdError`].
+	/// If any component is invalid, it will return an [`ArticleIdError`].
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArxivId, ArxivIdError};
+	/// use arxiv::{ArticleId, ArticleIdError};
 	///
-	/// let id = ArxivId::try_latest(2011, 1, "00001");
+	/// let id = ArticleId::try_latest(2011, 1, "00001");
 	/// assert!(id.is_ok());
 	/// ```
 	#[inline]
-	pub fn try_latest(year: i16, month: i8, number: &'a str) -> ArxivIdResult {
+	pub fn try_latest(year: i16, month: i8, number: &'a str) -> ArticleIdResult {
 		Self::try_new(year, month, number, ArticleVersion::Latest)
 	}
 
@@ -191,9 +191,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::ArxivId;
+	/// use arxiv::ArticleId;
 	///
-	/// let id = ArxivId::try_from("arXiv:2304.11188v1").unwrap();
+	/// let id = ArticleId::try_from("arXiv:2304.11188v1").unwrap();
 	/// assert_eq!(id.year(), 2023);
 	/// ```
 	#[must_use]
@@ -206,9 +206,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::ArxivId;
+	/// use arxiv::ArticleId;
 	///
-	/// let id = ArxivId::try_from("arXiv:2304.11188v1").unwrap();
+	/// let id = ArticleId::try_from("arXiv:2304.11188v1").unwrap();
 	/// assert_eq!(id.month(), 04);
 	/// ```
 	#[must_use]
@@ -221,9 +221,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::ArxivId;
+	/// use arxiv::ArticleId;
 	///
-	/// let id = ArxivId::try_from("arXiv:2304.11188v1").unwrap();
+	/// let id = ArticleId::try_from("arXiv:2304.11188v1").unwrap();
 	/// assert_eq!(id.number(), "11188");
 	/// ```
 	#[must_use]
@@ -236,9 +236,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId};
+	/// use arxiv::{ArticleId, ArticleVersion};
 	///
-	///  let id = ArxivId::try_from("arXiv:2304.11188v1").unwrap();
+	///  let id = ArticleId::try_from("arXiv:2304.11188v1").unwrap();
 	/// assert_eq!(id.version(), ArticleVersion::Num(1));
 	/// ```
 	#[must_use]
@@ -251,9 +251,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId};
+	/// use arxiv::{ArticleId, ArticleVersion};
 	///
-	/// let mut id = ArxivId::try_from("arXiv:2001.00001").unwrap();
+	/// let mut id = ArticleId::try_from("arXiv:2001.00001").unwrap();
 	/// assert_eq!(id.version(), ArticleVersion::Latest);
 
 	/// id.set_version(1);
@@ -268,9 +268,9 @@ impl<'a> ArxivId<'a> {
 	///
 	/// # Examples
 	/// ```
-	/// use arxiv::{ArticleVersion, ArxivId};
+	/// use arxiv::{ArticleId, ArticleVersion};
 	///
-	/// let mut id = ArxivId::try_from("arXiv:2001.00001v1").unwrap();
+	/// let mut id = ArticleId::try_from("arXiv:2001.00001v1").unwrap();
 	/// assert_eq!(id.version(), ArticleVersion::Num(1));
 	///
 	/// id.set_latest();
@@ -282,7 +282,7 @@ impl<'a> ArxivId<'a> {
 	}
 }
 
-impl<'a> Display for ArxivId<'a> {
+impl<'a> Display for ArticleId<'a> {
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		let mut year_str = self.year.to_string();
 		let (_, half_year) = year_str.as_mut_str().split_at(2);
@@ -295,19 +295,19 @@ impl<'a> Display for ArxivId<'a> {
 	}
 }
 
-impl<'a> TryFrom<&'a str> for ArxivId<'a> {
-	type Error = ArxivIdError;
+impl<'a> TryFrom<&'a str> for ArticleId<'a> {
+	type Error = ArticleIdError;
 
 	fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-		use ArxivIdError::*;
+		use ArticleIdError::*;
 
 		// break down the arxiv string into its components
-		let parts: Vec<&str> = value.split(ArxivId::TOKEN_COLON).collect();
+		let parts: Vec<&str> = value.split(ArticleId::TOKEN_COLON).collect();
 		if parts.len() != 2 || parts[0] != "arXiv" {
 			return Err(ExpectedBeginningLiteral);
 		}
 
-		let inner_parts: Vec<&str> = parts[1].split(ArxivId::TOKEN_DOT).collect();
+		let inner_parts: Vec<&str> = parts[1].split(ArticleId::TOKEN_DOT).collect();
 		if inner_parts.len() != 2 {
 			return Err(ExpectedNumberVv);
 		}
@@ -319,7 +319,7 @@ impl<'a> TryFrom<&'a str> for ArxivId<'a> {
 		let year = date[0..2].parse::<i16>().map_err(|_| InvalidYear)?;
 		let month = date[2..4].parse::<i8>().map_err(|_| InvalidMonth)?;
 		let (number, version) = parse_numbervv(numbervv).ok_or(ExpectedNumberVv)?;
-		ArxivId::try_new(year + 2000i16, month, number, version)
+		ArticleId::try_new(year + 2000i16, month, number, version)
 	}
 }
 
@@ -371,7 +371,7 @@ pub(crate) fn parse_numbervv(s: &str) -> Option<(&str, ArticleVersion)> {
 	if s.len() > number.len() {
 		let after_number = &mut s[number.len()..].chars().peekable();
 		if after_number
-			.next_if(|c| *c == ArxivId::TOKEN_VERSION)
+			.next_if(|c| *c == ArticleId::TOKEN_VERSION)
 			.is_some()
 		{
 			let consume = after_number
@@ -387,17 +387,17 @@ pub(crate) fn parse_numbervv(s: &str) -> Option<(&str, ArticleVersion)> {
 
 #[cfg(test)]
 mod test_display {
-	use super::ArxivId;
+	use super::ArticleId;
 
 	#[test]
 	fn with_version() {
-		let id = ArxivId::new_versioned(2007, 1, "0001", 1);
+		let id = ArticleId::new_versioned(2007, 1, "0001", 1);
 		assert_eq!(id.to_string(), "arXiv:0701.0001v1");
 	}
 
 	#[test]
 	fn without_version() {
-		let id = ArxivId::new_latest(2007, 1, "0001");
+		let id = ArticleId::new_latest(2007, 1, "0001");
 		assert_eq!(id.to_string(), "arXiv:0701.0001");
 	}
 }
@@ -420,7 +420,7 @@ mod tests_parse_ok {
 
 	#[test]
 	fn from_readme() {
-		let id = ArxivId::try_from("arXiv:0706.0001v1").unwrap();
+		let id = ArticleId::try_from("arXiv:0706.0001v1").unwrap();
 		assert_eq!(id.year, 2007);
 		assert_eq!(id.month, 6);
 		assert_eq!(id.number(), "0001");
@@ -429,31 +429,31 @@ mod tests_parse_ok {
 
 	#[test]
 	fn without_version() {
-		let id = ArxivId::try_from("arXiv:1501.00001");
-		assert_eq!(id, Ok(ArxivId::new_latest(2015, 1, "00001")));
+		let id = ArticleId::try_from("arXiv:1501.00001");
+		assert_eq!(id, Ok(ArticleId::new_latest(2015, 1, "00001")));
 	}
 
 	#[test]
 	fn with_version() {
-		let id = ArxivId::try_from("arXiv:9912.12345v2");
-		assert_eq!(id, Ok(ArxivId::new(2099, 12, "12345", ArticleVersion::Num(2))))
+		let id = ArticleId::try_from("arXiv:9912.12345v2");
+		assert_eq!(id, Ok(ArticleId::new(2099, 12, "12345", ArticleVersion::Num(2))))
 	}
 
 	#[test]
 	fn with_number_4_digits() {
-		let id1 = ArxivId::new_latest(2014, 1, "7878");
+		let id1 = ArticleId::new_latest(2014, 1, "7878");
 		assert_eq!(id1.to_string(), String::from("arXiv:1401.7878"));
 
-		let id2 = ArxivId::new_latest(2014, 12, "7878");
+		let id2 = ArticleId::new_latest(2014, 12, "7878");
 		assert_eq!(id2.to_string(), String::from("arXiv:1412.7878"));
 	}
 
 	#[test]
 	fn with_number_5_digits() {
-		let id1 = ArxivId::new_latest(2014, 1, "00008");
+		let id1 = ArticleId::new_latest(2014, 1, "00008");
 		assert_eq!(id1.to_string(), String::from("arXiv:1401.00008"));
 
-		let id2 = ArxivId::new_latest(2014, 12, "00008");
+		let id2 = ArticleId::new_latest(2014, 12, "00008");
 		assert_eq!(id2.to_string(), String::from("arXiv:1412.00008"));
 	}
 }
@@ -464,31 +464,31 @@ mod tests_parse_err {
 
 	#[test]
 	fn empty_string() {
-		let id = ArxivId::try_from("");
-		assert_eq!(id, Err(ArxivIdError::ExpectedBeginningLiteral));
+		let id = ArticleId::try_from("");
+		assert_eq!(id, Err(ArticleIdError::ExpectedBeginningLiteral));
 	}
 
 	#[test]
 	fn no_numbervv() {
-		let id = ArxivId::try_from("arXiv:1501");
-		assert_eq!(id, Err(ArxivIdError::ExpectedNumberVv));
+		let id = ArticleId::try_from("arXiv:1501");
+		assert_eq!(id, Err(ArticleIdError::ExpectedNumberVv));
 	}
 
 	#[test]
 	fn invalid_year() {
-		let maybe_id = ArxivId::try_latest(2006, 1, "00001");
-		assert_eq!(maybe_id, Err(ArxivIdError::InvalidYear));
+		let maybe_id = ArticleId::try_latest(2006, 1, "00001");
+		assert_eq!(maybe_id, Err(ArticleIdError::InvalidYear));
 	}
 
 	#[test]
 	fn invalid_month() {
-		let maybe_id = ArxivId::try_latest(2007, i8::MAX, "00001");
-		assert_eq!(maybe_id, Err(ArxivIdError::InvalidMonth));
+		let maybe_id = ArticleId::try_latest(2007, i8::MAX, "00001");
+		assert_eq!(maybe_id, Err(ArticleIdError::InvalidMonth));
 	}
 
 	#[test]
 	fn invalid_id() {
-		let maybe_id = ArxivId::try_latest(2007, 11, "");
-		assert_eq!(maybe_id, Err(ArxivIdError::InvalidId));
+		let maybe_id = ArticleId::try_latest(2007, 11, "");
+		assert_eq!(maybe_id, Err(ArticleIdError::InvalidId));
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 //!
 //! ## Identifiers
 //! ```rust
-//! use arxiv::{ArticleVersion, ArxivId};
+//! use arxiv::{ArticleId, ArticleVersion};
 //!
-//! let id = ArxivId::try_from("arXiv:9912.12345v2").unwrap();
+//! let id = ArticleId::try_from("arXiv:9912.12345v2").unwrap();
 //! assert_eq!(id.month(), 12);
 //! assert_eq!(id.year(), 2099);
 //! assert_eq!(id.number(), "12345");
@@ -15,20 +15,20 @@
 //!
 //! ## Categories
 //! ```rust
-//! use arxiv::{ArxivArchive, ArxivCategoryId, ArxivGroup};
+//! use arxiv::{Archive, CategoryId, Group};
 //!
-//! let category = ArxivCategoryId::try_from("astro-ph.HE").unwrap();
-//! assert_eq!(category.group(), ArxivGroup::Physics);
-//! assert_eq!(category.archive(), ArxivArchive::AstroPh);
+//! let category = CategoryId::try_from("astro-ph.HE").unwrap();
+//! assert_eq!(category.group(), Group::Physics);
+//! assert_eq!(category.archive(), Archive::AstroPh);
 //! assert_eq!(category.subject(), "HE");
 //! ```
 //!
 //! ## Stamps
 //! ```rust
-//! use arxiv::{ArxivArchive, ArxivCategoryId, ArxivStamp};
+//! use arxiv::{Archive, CategoryId, Stamp};
 //!
-//! let stamp = ArxivStamp::try_from("arXiv:0706.0001v1 [q-bio.CB] 1 Jun 2007").unwrap();
-//! assert_eq!(stamp.category, ArxivCategoryId::try_new(ArxivArchive::QBio, "CB").unwrap());
+//! let stamp = Stamp::try_from("arXiv:0706.0001v1 [q-bio.CB] 1 Jun 2007").unwrap();
+//! assert_eq!(stamp.category, CategoryId::try_new(Archive::QBio, "CB").unwrap());
 //! assert_eq!(stamp.submitted.year(), 2007);
 //! ```
 
@@ -42,7 +42,7 @@ pub use crate::stamp::*;
 
 /// Represents the versioned grammar that defines an arXiv identifier
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ArxivIdScheme {
+pub enum ArticleIdScheme {
 	/// Identifier scheme up to [March 2007][arxiv-march-2007]
 	///
 	/// [arxiv-march-2007]: https://info.arxiv.org/help/arxiv_identifier.html#identifiers-up-to-march-2007-9107-0703

--- a/src/stamp.rs
+++ b/src/stamp.rs
@@ -52,7 +52,7 @@ impl<'a> Stamp<'a> {
 
 	/// # Examples
 	/// ```
-	/// use arxiv::{Archive, CategoryId, ArticleId, Stamp};
+	/// use arxiv::{Archive, ArticleId, CategoryId, Stamp};
 	/// use jiff::civil::date;
 	///
 	/// let stamp = Stamp::new(


### PR DESCRIPTION
This renames types to remove the unnecessary `Arxiv` prefix, as followed:
- Rename `ArxivArchive` to `Archive`
- Rename `ArxivId` to `ArticleId`
- Rename `ArxivIdError` to `ArticleIdError`
- Rename `ArxivIdResult` to `ArticleIdResult`
- Rename `ArxivIdScheme` to `ArticleIdScheme`
- Rename `ArxivCategoryId` to `Category`
- Rename `ArxivGroup` to `Group`
- Rename `ArxivStamp` to `Stamp`
- Rename `ArxivStampError` to `StampError`
- Rename `ArxivStampResult` to `StampResult`